### PR TITLE
instead of calling out to `touch`, use Lwt_unix.openfile...

### DIFF
--- a/lib/FS_unix.ml
+++ b/lib/FS_unix.ml
@@ -120,7 +120,9 @@ let create {base} path =
   create_directory (Filename.dirname path) >>= function
   | `Error e -> Lwt.return (`Error e)
   | `Ok () ->
-    command "touch %s" path
+    Lwt_unix.openfile path [Lwt_unix.O_CREAT] 0o644 >>= fun fd ->
+    Lwt_unix.close fd >>= fun () ->
+    Lwt.return (`Ok ())
 
 let stat {base} path0 =
   let path = Fs_common.resolve_filename base path0 in


### PR DESCRIPTION
now, `command` (calling Sys.command) is only used for recursive remove