### PR TITLE
add `mem`; better error reporting

### DIFF
--- a/lib/fs_common.ml
+++ b/lib/fs_common.ml
@@ -46,13 +46,13 @@ let resolve_filename base filename =
   Filename.concat base name
 
 let string_of_error = function
-  | Unix.EEXIST -> "File already exists"
-  | Unix.EISDIR -> "Path is a directory"
-  | Unix.ENOENT -> "An element in the path doesn't exist"
-  | Unix.ENOSPC -> "Out of space"
-  | Unix.ENOTDIR -> "An element in the path isn't a directory"
-  | Unix.ENOTEMPTY -> "The directory is not empty"
-  | Unix.EUNKNOWNERR i -> Printf.sprintf ("Unknown error %d") i
+  | `File_already_exists s -> "File already exists: " ^ s
+  | `Is_a_directory s -> "Path is a directory: " ^ s
+  | `No_directory_entry (_, s) -> "An element in the path doesn't exist: " ^ s
+  | `No_space -> "Out of space"
+  | `Not_a_directory s -> "An element in the path isn't a directory: " ^ s
+  | `Directory_not_empty s -> "The directory is not empty: " ^ s
+  | `Unknown_error s -> "Unknown error: : " ^ s
 
 let map_error err reqd_string = 
   match err with
@@ -76,7 +76,7 @@ let mem_impl base name =
         )
   (function
           | Unix.Unix_error (Unix.ENOENT, _, _) -> Lwt.return (`Ok false)
-          | Unix.Unix_error (err, _, _) -> err_catcher name)
+          | e -> err_catcher name e)
 
 let read_impl base name off reqd_len =
   if reqd_len < 0 then return (`Error (`Unknown_error "can't read negative bytes"))

--- a/lib/kvro_fs_unix.ml
+++ b/lib/kvro_fs_unix.ml
@@ -21,6 +21,7 @@ type +'a io = 'a Lwt.t
 type id = string
 type error =
   | Unknown_key of string
+  | Failure of string
 type page_aligned_buffer = Cstruct.t
 
 type t = {
@@ -35,6 +36,11 @@ let disconnect t =
   return ()
 
 let id {base} = base
+
+let mem {base} name =
+  Fs_common.mem_impl base name >|= function
+   | `Error s -> `Error (Failure s)
+   | `Ok data -> `Ok data
 
 let read {base} name off len =
   Fs_common.read_impl base name off len >|= function

--- a/lib/kvro_fs_unix.ml
+++ b/lib/kvro_fs_unix.ml
@@ -39,15 +39,17 @@ let id {base} = base
 
 let mem {base} name =
   Fs_common.mem_impl base name >|= function
-   | `Error s -> `Error (Failure s)
+   | `Error e -> `Error (Failure (Fs_common.string_of_error e))
    | `Ok data -> `Ok data
 
 let read {base} name off len =
   Fs_common.read_impl base name off len >|= function
-   | `Error _ -> `Error (Unknown_key name)
+   | `Error (`No_directory_entry (_, s))-> `Error (Unknown_key s)
+   | `Error e -> `Error (Failure (Fs_common.string_of_error e))
    | `Ok data -> `Ok data
 
 let size {base} name =
   Fs_common.size_impl base name >|= function
-   | `Error _ -> `Error (Unknown_key name)
+   | `Error (`No_directory_entry (_, s))-> `Error (Unknown_key s)
+   | `Error e -> `Error (Failure (Fs_common.string_of_error e))
    | `Ok data -> `Ok data


### PR DESCRIPTION
mirage/mirage#147 requests all implementors of `KV_RO` to provide a `mem` function. Add one, and try to leave things a little better than we found them.