### PR TITLE
Types lwt

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
-PKG lwt.unix cstruct mirage-runtime mirage-types.lwt oUnit ptime rresult
+PKG lwt.unix cstruct mirage-runtime mirage-types-lwt oUnit ptime rresult
 PKG ptime.clock.os
 
 S lib/

--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 true: warn_error(+1..49), warn(A-4-41-44)
 true: short_paths
 
-true: package(lwt lwt.unix mirage-types cstruct.lwt mirage-runtime)
+true: package(lwt lwt.unix mirage-types mirage-types-lwt cstruct.lwt mirage-runtime)
 
 <lib>: include
 <lib_test/*>: package(unix ptime mirage-clock-unix alcotest oUnit rresult)

--- a/lib/fS_unix.ml
+++ b/lib/fS_unix.ml
@@ -134,22 +134,6 @@ let remove path =
   Lwt.catch (fun () -> rm false (Filename.dirname path) (Filename.basename path) >|= fun () -> Ok ())
   (fun e -> FS_common.write_err_catcher e)
 
-let format {base} _ =
-  assert (base <> "/");
-  assert (base <> "");
-  (* FIXME, format should return a write_error, see https://github.com/mirage/mirage/commit/96d025a8923b4ed138a13f7c825f466693c18ea2#commitcomment-20154024  *)
-  remove base >|= function
-  | Ok _ as x -> x
-  | Error e   ->
-    match e with
-    | `Is_a_directory
-    | `Not_a_directory
-    | `No_directory_entry
-    | `Msg _ as e          -> Error e
-    | `Directory_not_empty -> Error (`Msg "Cannot remove a non-empty directory")
-    | `File_already_exists -> Error (`Msg "Cannot create a file with a duplicate name")
-    | `No_space            -> Error (`Msg "No space left on the block device")
-
 let destroy {base} path =
   let path = FS_common.resolve_filename base path in
   remove path

--- a/lib/fS_unix.mli
+++ b/lib/fS_unix.mli
@@ -17,8 +17,6 @@
 
 (** Loopback implementation of the FS signature. *)
 
-include V1.FS
-  with type +'a io = 'a Lwt.t
-   and type page_aligned_buffer = Cstruct.t
+include V1_LWT.FS
 
 val connect : string -> t io

--- a/opam
+++ b/opam
@@ -17,7 +17,7 @@ depends: [
   "ocamlfind" {build}
   "cstruct" {>= "1.4.0"}
   "mirage-types" {>= "3.0.0"}
-  "mirage-types-lwt"
+  "mirage-types-lwt" {>= "3.0.0"}
   "mirage-runtime"
   "lwt"
   "rresult"           {test}

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version         = "%%VERSION_NUM%%"
 description     = "Mirage filesystem driver for Unix"
-requires        = "lwt lwt.unix mirage-types cstruct.lwt mirage-runtime"
+requires        = "lwt lwt.unix mirage-types mirage-types-lwt cstruct.lwt mirage-runtime"
 archive(byte)   = "mirage-fs-unix.cma"
 plugin(byte)    = "mirage-fs-unix.cma"
 plugin(native)  = "mirage-fs-unix.cmxs"


### PR DESCRIPTION
this includes changes for both https://github.com/mirage/mirage/pull/735 and https://github.com/mirage/mirage/pull/733 (by removing `format` -- IMHO this is sensible here, but @djs55 @yomimono may have a different opinion -- the implementation used to remove the root directory which can be achieved by other means)