### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@
 * Parent of base directory is base directory (/../ -> /)
 
 1.1.0 (2014-06-09):
-* Add an `FS_unix` module which implements `V1_LWT.FS`
+* Add an `FS_unix` module which implements `Mirage_types_lwt.FS`
 
 1.0.0 (2013-12-16):
 * First public release.


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.