### PR TITLE
fix destroy of a directory:

### DIFF
--- a/mirage-fs-unix.opam
+++ b/mirage-fs-unix.opam
@@ -1,28 +1,37 @@
-opam-version: "1.2"
+opam-version: "2.0"
 authors:      [ "Mindy Preston" "Hannes Mehnert" "Anil Madhavapeddy"
                 "Thomas Gazagnaire" ]
 maintainer:   [ "anil@recoil.org" "thomas@gazagnaire.org"]
 homepage:     "https://github.com/mirage/mirage-fs-unix"
-dev-repo:     "https://github.com/mirage/mirage-fs-unix.git"
+dev-repo:     "git+https://github.com/mirage/mirage-fs-unix.git"
 bug-reports:  "https://github.com/mirage/mirage-fs-unix/issues"
 doc:          "https://mirage.github.io/mirage-fs-unix/"
 tags:         [ "org:mirage" ]
 build: [
   ["jbuilder" "subst" "-p" name ] {pinned}
   ["jbuilder" "build" "-p" name "-j" jobs]
+  ["jbuilder" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build & >="1.0+beta7"}
+  "ocaml" {>= "4.04.2"}
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"
   "mirage-kv-lwt" {>= "1.0.0"}
   "mirage-fs-lwt" {>= "1.0.0"}
   "lwt"
-  "rresult" {test}
-  "mirage-clock-unix" {test & >= "1.2.0"}
-  "alcotest" {test & >= "0.7.1"}
-  "ptime" {test}
+  "rresult" {with-test}
+  "mirage-clock-unix" {with-test & >= "1.2.0"}
+  "alcotest" {with-test & >= "0.7.1"}
+  "ptime" {with-test}
 ]
-available: [ ocaml-version >= "4.04.2"]
+synopsis: "Passthrough filesystem for MirageOS on Unix"
+description: """
+This is a pass-through Mirage filesystem to an underlying Unix directory.  The
+interface is intended to support eventual privilege separation (e.g. via the
+Casper daemon in FreeBSD 11).
+
+The current version supports the `Mirage_fs.S` and `Mirage_fs_lwt.S` signatures
+defined in the `mirage-fs` package.
+"""

--- a/test/test_fs_unix.ml
+++ b/test/test_fs_unix.ml
@@ -418,7 +418,7 @@ let destroy () =
   | Error _ -> cleanup () >>= fun () -> failf "create failed"
   | Ok () ->
     FS_impl.listdir fs "/" >>= function
-    | Ok []   -> cleanup ()
+    | Ok []   -> Lwt.return_unit
     | Ok _    -> failf "something exists after destroy"
     | Error _ -> failf "error in listdir"
 


### PR DESCRIPTION
```bash
# ls -lR /tmp/foo
total 1
-rw-r--r--  1 hannes  wheel  0  8 Nov 22:02 bar
```

in utop we destroy the `foo/bar`:
```OCaml
# FS_unix.connect "/tmp" >>= fun fs -> FS_unix.destroy fs "foo/bar" ;;
- : (unit, FS_unix.write_error) result = Ok ()
```
result as expected:
```bash
# ls -lR /tmp/foo
total 0
```
now we attempt to destroy the directory:
```OCaml
# FS_unix.connect "/tmp" >>= fun fs -> FS_unix.destroy fs "foo" ;;
- : (unit, FS_unix.write_error) result = Ok ()
```

result (unexpected):
```
# ls -lR /tmp/foo
total 0
```

This is rather unexpected -- the directory `foo` is still around.  With the PR below, the latter `FS_unix.destroy` will erase the `/tmp/foo` directory. The latest command results in:
```bash
# ls -lR /tmp/foo
ls: /tmp/foo: No such file or directory
```

debugged and fixed with @linse