### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-fs-unix.opam
+++ b/mirage-fs-unix.opam
@@ -14,7 +14,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "ocaml" {>= "4.04.2"}
   "cstruct" {>= "3.2.0"}
   "cstruct-lwt"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.